### PR TITLE
 Add Discord and Slack Community Link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@
   <a href="https://github.com/OpenDevin/OpenDevin/stargazers"><img src="https://img.shields.io/github/stars/opendevin/opendevin?style=for-the-badge" alt="Stargazers"></a>
   <a href="https://github.com/OpenDevin/OpenDevin/issues"><img src="https://img.shields.io/github/issues/opendevin/opendevin?style=for-the-badge" alt="Issues"></a>
   <a href="https://github.com/OpenDevin/OpenDevin/blob/main/LICENSE"><img src="https://img.shields.io/github/license/opendevin/opendevin?style=for-the-badge" alt="MIT License"></a>
-  <a href="https://discord.gg/mBuDGRzzES"><img src="https://discord.com/assets/07dca80a102d4149e9736d4b162cff6f.ico" alt="Discord" height="30" width="30"></a>
-
+  </br>
+  <a href="https://join.slack.com/t/opendevin/shared_invite/zt-2etftj1dd-X1fDL2PYIVpsmJZkqEYANw"><img src="https://img.shields.io/badge/Slack-Join%20Us-red?logo=slack&logoColor=white&style=for-the-badge" alt="Join our Slack community"></a>
+  <a href="https://discord.gg/mBuDGRzzES"><img src="https://img.shields.io/badge/Discord-Join%20Us-purple?logo=discord&logoColor=white&style=for-the-badge" alt="Join our Discord community"></a>
 </div>
 
 <!-- PROJECT LOGO -->


### PR DESCRIPTION
This pull request enhances the README.md file by adding a Discord and Slack community link to the OpenDevin project. The addition includes a Discord and Slack logo with a hyperlink to the project's Discord server invite and Slack invite, ensuring easy access for users interested in joining the community. This update maintains consistency with existing style elements, such as badges for other community platforms like Slack. By incorporating the Discord link, this pull request aims to promote community engagement and improve user accessibility within the project.